### PR TITLE
Update to polyline docker build to allow use of valhalla for larger pbf files.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,12 @@ RUN wget -qO- https://dl.google.com/go/go1.10.linux-amd64.tar.gz | tar -C /usr/l
 RUN mkdir -p "${GOPATH}"
 ENV PATH="${PATH}:/usr/local/go/bin:${GOPATH}/bin"
 
+# Install valhalla (Requires Ubuntu 16.04)
+RUN add-apt-repository -y ppa:valhalla-core/valhalla && \
+    apt-get update
+
+RUN apt-get install -y valhalla-bin
+
 # change working dir
 ENV WORKDIR /code/pelias/polylines
 WORKDIR ${WORKDIR}
@@ -17,6 +23,12 @@ ENV PATH $PATH:$GOROOT/bin:$GOPATH/bin
 
 # get go dependencies
 RUN go get github.com/missinglink/pbf
+
+RUN valhalla_build_config \
+  --mjolnir-tile-dir '/data/valhalla/valhalla_tiles' \
+  --mjolnir-tile-extract '/data/valhalla/valhalla_tiles.tar' \
+  --mjolnir-timezone '/data/valhalla/valhalla_tiles/timezones.sqlite' \
+  --mjolnir-admin '/data/valhalla/valhalla_tiles/admins.sqlite' > valhalla.json
 
 # copy package.json first to prevent npm install being rerun when only code changes
 COPY ./package.json ${WORKDIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
 # base image
-FROM pelias/baseimage
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y locales apt-utils iputils-ping curl wget git-core autoconf automake libtool pkg-config python
+
+RUN apt-get install -y software-properties-common && \
+    apt-get update
+
+# install nodejs
+ENV NODE_VERSION='10.14.0'
+RUN git clone 'https://github.com/isaacs/nave.git' /code/nave && /code/nave/nave.sh 'usemain' "${NODE_VERSION}" && rm -rf ~/.nave /code/nave
 
 # install go 1.10
 ENV GOPATH=/usr/src/.go


### PR DESCRIPTION
This updates the polyline code to generate polylines using valhalla when working with larger pbf files. Right now this docker image has been modified to be use ubuntu:16.04 as base instead of pelias/baseimage. This should eventually not be needed once the fix is fully incorporated into base pelias. Ideally this will use a later ubuntu version, but no nice recipe exists to install valhalla on later versions of ubuntu. It will need to be built from source, and there are still some issues to work through there.